### PR TITLE
Bump the UAPTools version to 1.0.2

### DIFF
--- a/src/Microsoft.DotNet.Build.Tasks/PackageFiles/optional-tool-runtime/optional.json
+++ b/src/Microsoft.DotNet.Build.Tasks/PackageFiles/optional-tool-runtime/optional.json
@@ -3,7 +3,7 @@
     "net45": {
       "dependencies": {
         "Microsoft.DotNet.IBCMerge": "4.6.0-alpha-00001",
-        "Microsoft.DotNet.UAP.TestTools" : "1.0.1"
+        "Microsoft.DotNet.UAP.TestTools" : "1.0.2"
        }
     }
   },


### PR DESCRIPTION
Bump the UAPTools version to 1.0.2 to use the updated runner.